### PR TITLE
Compatibility with C5, use terminal42/contao-build-tools, german translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 # Composer bin
 /tools/*/vendor
 /tools/*/composer.lock
+
+# PHPStorm
+.idea/
+
+# Mac
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "globalcitizen/php-iban": "^4.2"
     },
     "require-dev": {
-        "contao/manager-plugin": "^2.3"
+        "contao/manager-plugin": "^2.3",
+        "terminal42/contao-build-tools": "dev-main"
     },
     "conflict": {
         "contao/manager-plugin": "<2.0 || >=3.0"
@@ -29,7 +30,19 @@
     "extra":{
         "contao-manager-plugin": "TwoBiased\\ContaoValidationBundle\\ContaoManager\\Plugin"
     },
+    "config": {
+        "allow-plugins": {
+            "contao-components/installer": true,
+            "php-http/discovery": true,
+            "contao/manager-plugin": true,
+            "terminal42/contao-build-tools": true
+        }
+    },
     "scripts": {
-        "cs-fixer": "@php tools/ecs/vendor/bin/ecs check src tools/ecs/config --config tools/ecs/config/default.php --fix --ansi"
+        "all": [
+            "@cs-fixer",
+            "@rector",
+            "@phpstan"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~8.0",
-        "contao/core-bundle": "^4.13",
+        "contao/core-bundle": "^4.13 || ^5.3",
         "globalcitizen/php-iban": "^4.2"
     },
     "require-dev": {

--- a/src/DependencyInjection/TwoBiasedContaoValidationExtension.php
+++ b/src/DependencyInjection/TwoBiasedContaoValidationExtension.php
@@ -23,7 +23,7 @@ class TwoBiasedContaoValidationExtension extends BaseExtension
     {
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__.'/../Resources/config')
+            new FileLocator(__DIR__.'/../Resources/config'),
         );
 
         $loader->load('services.yml');

--- a/src/EventListener/AddCustomRegexpListener.php
+++ b/src/EventListener/AddCustomRegexpListener.php
@@ -20,11 +20,11 @@ class AddCustomRegexpListener
     /**
      * @Hook("addCustomRegexp")
      */
-    public function __invoke(string $regexp, $input, Widget $widget): bool
+    public function __invoke(string $regexp, mixed $input, Widget $widget): bool
     {
         if ('iban' === $regexp) {
             if (verify_iban($input)) {
-                if ($widget->ibanAllowedCountryCodes) {
+                if ($widget->ibanAllowedCountryCodes) { // @phpstan-ignore-line
                     $countryCodes = explode(',', $widget->ibanAllowedCountryCodes);
 
                     if (!\in_array(iban_get_country_part($input), $countryCodes, true)) {

--- a/src/EventListener/DataContainer/FormFieldListener.php
+++ b/src/EventListener/DataContainer/FormFieldListener.php
@@ -21,9 +21,9 @@ class FormFieldListener
     /**
      * @Callback(table="tl_form_field", target="config.onload")
      */
-    public function adjustDcaByType(DataContainer $dc = null): void
+    public function adjustDcaByType(DataContainer|null $dc = null): void
     {
-        if (($objField = FormFieldModel::findByPk($dc->id)) !== null) {
+        if (($objField = FormFieldModel::findById($dc->id)) !== null) {
             switch ($objField->type) {
                 case 'text':
                     $GLOBALS['TL_DCA']['tl_form_field']['fields']['rgxp']['options'][] = 'iban';
@@ -35,7 +35,7 @@ class FormFieldListener
     /**
      * @Callback(table="tl_form_field", target="fields.ibanAllowedCountryCodes.options")
      */
-    public function getIbanCountryCodes(DataContainer $dc = null): array
+    public function getIbanCountryCodes(DataContainer|null $dc = null): array
     {
         $countries = [];
 

--- a/src/Resources/contao/languages/de/default.xlf
+++ b/src/Resources/contao/languages/de/default.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.1">
+  <file datatype="php" original="src/Resources/contao/languages/en/default.php" source-language="en">
+    <body>
+      <trans-unit id="ERR.iban">
+        <source>Pleaser enter a valid IBAN!</source>
+        <target>Bitte geben Sie eine gültige IBAN ein!</target>
+      </trans-unit>
+      <trans-unit id="ERR.ibanRestrictedCountryCodes">
+        <source>The IBAN must begin with one of the following country code: %s</source>
+        <target>Die IBAN muss mit einem der folgenden Ländercodes beginnen: %s</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>
+

--- a/src/Resources/contao/languages/de/tl_form_field.xlf
+++ b/src/Resources/contao/languages/de/tl_form_field.xlf
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.1">
+  <file datatype="php" original="src/Resources/contao/languages/en/tl_form_field.php" source-language="en">
+    <body>
+      <trans-unit id="tl_form_field.iban.0">
+        <source>IBAN</source>
+        <target>IBAN</target>
+      </trans-unit>
+      <trans-unit id="tl_form_field.iban.1">
+        <source>Checks whether the input is a valid IBAN.</source>
+        <target>Prüft, ob die Eingabe eine gültige IBAN ist.</target>
+      </trans-unit>
+      <trans-unit id="tl_form_field.ibanAllowedCountryCodes.0">
+        <source>Allowed IBAN country codes</source>
+        <target>Zulässige IBAN-Ländercodes</target>
+      </trans-unit>
+      <trans-unit id="tl_form_field.ibanAllowedCountryCodes.1">
+        <source>Select the allowed country codes or leave the slection empty to accept all country codes.</source>
+        <target>Wählen Sie die zulässigen Ländercodes aus oder lassen Sie die Auswahl leer, um alle Ländercodes zu akzeptieren.</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Hi,

thx a lot for this extension. I just added the following
- compatibility with Contao 5
- use terminal42/contao-build-tools
- add german translation

Each of the commits should work on it's own. So - for example - if you don't like the contao-build-tools I could provide a different PR without those changes.